### PR TITLE
Customizable faces for header line, and improved display logic

### DIFF
--- a/topsy.el
+++ b/topsy.el
@@ -145,8 +145,9 @@ string above the top of the window."
           (vertical-motion -1)
           (let ((bol (point))
                 (eol (1- (window-start))))
-            (font-lock-ensure bol eol)
-            (buffer-substring bol eol))))))
+            (when (< bol eol)
+              (font-lock-ensure bol eol)
+              (buffer-substring bol eol)))))))
 
 (defun topsy--beginning-of-defun ()
   "Return the first line of a partially visible defun.

--- a/topsy.el
+++ b/topsy.el
@@ -148,11 +148,11 @@ the defun but not when showing the previous line."
                 (add-face-text-property 0 (length line) 'topsy-highlight t line)
                 line))))
         (progn (goto-char (window-start))
-               (let ((bol (point-at-bol 0))
-                     (eol (point-at-eol 0)))
-                 (when (< eol (window-start))
-                   (font-lock-ensure bol eol)
-                   (buffer-substring bol eol)))))))
+               (vertical-motion -1)
+               (let ((bol (point))
+                     (eol (1- (window-start))))
+                 (font-lock-ensure bol eol)
+                 (buffer-substring bol eol))))))
 
 (defun topsy--magit-section ()
   "Return the header line in a `magit-section-mode' buffer."


### PR DESCRIPTION
### Add two new customizable faces, `topsy` and `topsy-highlight`.

The `topsy` face is used for the header-line when `topsy-mode` is enabled.  It inherits from the default face, so that the text in the header line matches the contents of the buffer. The `topsy-highlight` face is applied (with low priority) when topsy is showing the first line of a defun (see below).

To go back to the previous appearance (using header-line face), customize the `topsy` face to nil or remove its `:inherit default` attribute.

### Properly handle narrowed buffers

The first line of the defun is shown even if it is only partly within a narrowed buffer.

### Improve logic for finding the first line of a defun

The first line of a defun is shown only if it is partially visible. If the defun is entirely outside the window, its first line is not shown.

Fixes #1

### Show previous line when a defun starts at the top of a window

Finally, when there is no partially visible defun, show the line that is above the top of the window. This gives a smooth scrolling effect, where the header line looks and acts just like a normally scrolling part of the buffer. When you scroll up, the top line of text will appear in the header line, which then becomes sticky when you scroll past a defun.

Buffer text shown in this way doesn't have the `topsy-highlight` face.

https://user-images.githubusercontent.com/552952/140688151-e99393ce-433d-4885-9e1d-d3001faddb72.mp4

