### PR TITLE
Remap `header-line` face to `topsy-header-line` in `topsy-mode`

### DIFF
--- a/topsy.el
+++ b/topsy.el
@@ -39,6 +39,7 @@
 ;;;; Requirements
 
 (require 'subr-x)
+(require 'face-remap)
 
 ;;;; Variables
 
@@ -53,6 +54,9 @@
 
 (defvar-local topsy-fn nil
   "Function that returns the header in a buffer.")
+
+(defvar-local topsy--face-remap nil
+  "Cookie returned by `face-remap-add-relative'.")
 
 ;;;; Customization
 
@@ -75,6 +79,15 @@ nil key defines the default function."
   :type '(alist :key-type symbol
                 :value-type function))
 
+(defface topsy-header-line '((t :inherit default))
+  "Topsy header line face.
+
+The default specification overrides the `header-line' face, which
+is often not appropriate for a sticky header.  To use the
+`header-line' face instead, remove the `:inherit' attribute:
+
+\(custom-set-faces \\='(topsy-header-line ((t :inherit nil))))")
+
 ;;;; Commands
 
 ;;;###autoload
@@ -92,7 +105,9 @@ Return non-nil if the minor mode is enabled."
         ;; Enable the mode
         (setf topsy-fn (or (alist-get major-mode topsy-mode-functions)
                            (alist-get nil topsy-mode-functions))
-              header-line-format 'topsy-header-line-format))
+              header-line-format 'topsy-header-line-format
+              topsy--face-remap (face-remap-add-relative 'header-line
+                                                         'topsy-header-line)))
     ;; Disable mode
     (when (eq header-line-format 'topsy-header-line-format)
       ;; Restore previous buffer local value of header line format if
@@ -100,7 +115,8 @@ Return non-nil if the minor mode is enabled."
       (kill-local-variable 'header-line-format)
       (when topsy-old-hlf
         (setf header-line-format topsy-old-hlf
-              topsy-old-hlf nil)))))
+              topsy-old-hlf nil)))
+    (face-remap-remove-relative topsy--face-remap)))
 
 ;;;; Functions
 


### PR DESCRIPTION
Many themes change the `header-line` face to be similar to the faces used by the mode line. This is often not a good fit for showing a sticky header. To allow the Topsy face to be customized independently of the usual header line, this PR remaps the `header-line` face to a new `topsy-header-line` face when Topsy is active.

By default, the `topsy-header-line` face just inherits from `default`, so it is displayed just as the rest of the buffer text would be. To revert to the original behaviour of using the `header-line` face, you need to do
```elisp
(custom-set-faces '(topsy-header-line ((t :inherit nil))))
```

This PR is the first in a series that splits out the functionality of #7.