### PR TITLE
Show beginning-of-defun only if the top of the window is inside a defun

### DIFF
--- a/topsy.el
+++ b/topsy.el
@@ -87,6 +87,14 @@ nil key defines the default function."
   "Widen buffer before finding beginning of defun."
   :type 'boolean)
 
+(defcustom topsy-defun-before-end nil
+  "Only show beginning of defun if it is partially visible.
+
+If the top line of the window is past the end of the defun, do
+not show the beginning of the defun.  Call `end-of-defun' to find
+the end of the defun."
+  :type 'boolean)
+
 ;;;; Commands
 
 ;;;###autoload
@@ -119,18 +127,23 @@ Return non-nil if the minor mode is enabled."
 (defun topsy--beginning-of-defun ()
   "Return the first line of the defun at the top of the window.
 
-Return nil when the defun begins on the top line of the window.
-Find the beginning of the defun by calling `beginning-of-defun'.
-Ignore buffer narrowing if `topsy-defun-ignore-narrowing' is
-non-nil."
-  (when (> (window-start) 1)
-    (save-excursion
-      (save-restriction
-        (when topsy-defun-ignore-narrowing
-          (widen))
-        (goto-char (window-start))
-        (let ((bod (ignore-errors (beginning-of-defun) (point)))
-              (eol (pos-eol)))
+Return nil when the defun begins on the top line of the window,
+or when `topsy-defun-before-end' is non-nil and the defun ends
+above the window.  Find the beginning of the defun by calling
+`beginning-of-defun' and its end by calling `end-of-defun', but
+only if `topsy-defun-before-end' is non-nil.  Ignore buffer
+narrowing if `topsy-defun-ignore-narrowing' is non-nil."
+  (save-excursion
+    (save-restriction
+      (when topsy-defun-ignore-narrowing
+        (widen))
+      (goto-char (window-start))
+      (let ((bod (ignore-errors (beginning-of-defun) (point)))
+            (eol (pos-eol))
+            (eod (when topsy-defun-before-end
+                   (ignore-errors (end-of-defun) (point)))))
+        (when (and bod (< bod (window-start))
+                   (or (not eod) (>= eod (window-start))))
           (font-lock-ensure bod eol)
           (buffer-substring bod eol))))))
 

--- a/topsy.el
+++ b/topsy.el
@@ -83,6 +83,10 @@ nil key defines the default function."
   :type '(alist :key-type symbol
                 :value-type function))
 
+(defcustom topsy-defun-ignore-narrowing nil
+  "Widen buffer before finding beginning of defun."
+  :type 'boolean)
+
 ;;;; Commands
 
 ;;;###autoload
@@ -113,13 +117,22 @@ Return non-nil if the minor mode is enabled."
 ;;;; Functions
 
 (defun topsy--beginning-of-defun ()
-  "Return the line moved to by `beginning-of-defun'."
+  "Return the first line of the defun at the top of the window.
+
+Return nil when the defun begins on the top line of the window.
+Find the beginning of the defun by calling `beginning-of-defun'.
+Ignore buffer narrowing if `topsy-defun-ignore-narrowing' is
+non-nil."
   (when (> (window-start) 1)
     (save-excursion
-      (goto-char (window-start))
-      (beginning-of-defun)
-      (font-lock-ensure (point) (pos-eol))
-      (buffer-substring (point) (pos-eol)))))
+      (save-restriction
+        (when topsy-defun-ignore-narrowing
+          (widen))
+        (goto-char (window-start))
+        (let ((bod (ignore-errors (beginning-of-defun) (point)))
+              (eol (pos-eol)))
+          (font-lock-ensure bod eol)
+          (buffer-substring bod eol))))))
 
 (declare-function magit-current-section "magit-section" nil t)
 (declare-function magit-section-ident "magit-section" nil t)


### PR DESCRIPTION
This PR makes two changes to the `topsy--beginning-of-defun` function:

* It checks if the top of the window is actually inside a defun. If not, it returns nil, which results in a blank header line (but see below).
* It widens the buffer before finding the beginning-of-defun, in case only part of the defun is visible. This is a small change that affects the same code as the rest of this PR, so I decided to include it here.

This is the second in a series of PRs that splits out the functionality of #7. The next PR in this series  (#18) makes it possible to use the header line as an extra text line when there is no sticky header, for example when the beginning of the window is not inside a defun. Together, they fix bug #1.