### PR TITLE
Use header as extra text line when there is no sticky header

### DIFF
--- a/topsy.el
+++ b/topsy.el
@@ -52,14 +52,14 @@
 
 (defconst topsy-header-line-format
   '(:eval (list (propertize " " 'display '((space :align-to 0)))
-                (funcall topsy-fn)))
+                (topsy--header-string)))
   "The header line format used by `topsy-mode'.")
 (put 'topsy-header-line-format 'risky-local-variable t)
 
 (defvar-local topsy-old-hlf nil
   "Preserves the old value of `header-line-format'.")
 
-(defvar-local topsy-fn nil
+(defvar-local topsy-fn #'ignore
   "Function that returns the header in a buffer.")
 
 ;;;; Customization
@@ -82,6 +82,11 @@ Each function provides the sticky header string in a mode.  The
 nil key defines the default function."
   :type '(alist :key-type symbol
                 :value-type function))
+
+(defcustom topsy-previous-line-fallback t
+  "Show line above the window start instead of blank header."
+  :type '(choice (const :tag "Show previous line" t)
+                 (const :tag "Leave header blank" nil)))
 
 ;;;; Commands
 
@@ -111,6 +116,20 @@ Return non-nil if the minor mode is enabled."
               topsy-old-hlf nil)))))
 
 ;;;; Functions
+
+(defun topsy--header-string ()
+  "Return string found by `topsy-fn' or line above window start."
+  (or (funcall topsy-fn)
+      (when topsy-previous-line-fallback
+        ;; Return the line preceding window-start
+        (save-excursion
+          (goto-char (window-start))
+          (vertical-motion -1)
+          (let ((bol (point))
+                (eol (1- (window-start))))
+            (when (< bol eol)
+              (font-lock-ensure bol eol)
+              (buffer-substring bol eol)))))))
 
 (defun topsy--beginning-of-defun ()
   "Return the line moved to by `beginning-of-defun'."


### PR DESCRIPTION
When the `topsy-mode-functions` fail to return a sticky header (as with PR #17 when the top of the window is not in a defun), use the header as an extra line displaying the contents of the buffer immediately above the window. This fallback can be disabled with the new `topsy-previous-line-fallback` option.

Together with PR #17, this fixes bug #1 and supercedes #13.

This PR also introduces a new `topsy-highlight` face which is applied to the header line text whenever it is an actual sticky header, not just the line above the window. By default, it is fairly subtle but does the job of telling you what you're seeing, without being too jarring as you scroll through the buffer.

When combined with PR #16, the extra line of text is shown just like the rest of the buffer text, but sticky headers are slightly emphasized. The effect can be seen in the video attached to #7.

This is the third and last in a series of PRs that splits apart the functionality of #7. The combined effect can be seen in https://github.com/roshanshariff/topsy.el/tree/master.

https://user-images.githubusercontent.com/552952/140688151-e99393ce-433d-4885-9e1d-d3001faddb72.mp4